### PR TITLE
Add cli input var support

### DIFF
--- a/src/cr_kyoushi/generator/cli.py
+++ b/src/cr_kyoushi/generator/cli.py
@@ -106,7 +106,6 @@ def convert_input_vars(
 
     # load the defined input variables
     for _id, _input in inputs_config.items():
-        print(f"processing {_id}")
         if _id in input_vars:
             _input.value = input_vars.pop(_id)
 

--- a/src/cr_kyoushi/generator/config.py
+++ b/src/cr_kyoushi/generator/config.py
@@ -75,6 +75,9 @@ class Input(BaseModel):
         alias="default",
     )
 
+    class Config:
+        allow_population_by_field_name = True
+
 
 class InputName(StrictStr):
     regex = re.compile(r"^[\w\d-]*$")

--- a/src/cr_kyoushi/generator/config.py
+++ b/src/cr_kyoushi/generator/config.py
@@ -9,6 +9,7 @@ from typing import (
     List,
     Optional,
     Pattern,
+    Union,
 )
 
 from pydantic import (
@@ -56,6 +57,10 @@ class JinjaConfig(BaseModel):
     )
 
 
+class MissingInput(BaseModel):
+    pass
+
+
 class Input(BaseModel):
     model: str = Field(
         ..., description="The python type hint to use for loading this input"
@@ -68,8 +73,10 @@ class Input(BaseModel):
     description: Optional[str] = Field(
         None, description="A textual description of the input variable"
     )
-    value: Optional[str] = Field(
-        None, description="The string encoded value assigned to the input"
+    value: Union[str, MissingInput] = Field(
+        MissingInput(),
+        description="The json encoded value assigned to the input",
+        alias="default",
     )
 
 

--- a/src/cr_kyoushi/generator/config.py
+++ b/src/cr_kyoushi/generator/config.py
@@ -66,10 +66,6 @@ class Input(BaseModel):
         ..., description="The python type hint to use for loading this input"
     )
     required: bool = Field(False, description="If the input is required or not.")
-    prompt: Optional[str] = Field(
-        None,
-        description="The input prompt message to use when the required input is not passed via CLI.",
-    )
     description: Optional[str] = Field(
         None, description="A textual description of the input variable"
     )

--- a/src/cr_kyoushi/generator/config.py
+++ b/src/cr_kyoushi/generator/config.py
@@ -84,6 +84,10 @@ class InputName(StrictStr):
     regex = re.compile(r"^[\w\d-]*$")
 
 
+InputVarsDict = Dict[InputName, str]
+InputDict = Dict[InputName, Input]
+
+
 class Config(BaseModel):
     """Kyoushi Generator tool configuration model
 
@@ -117,7 +121,7 @@ class Config(BaseModel):
         None,
         description="A hard coded seed to use for instance creation with this model. Can be overwritten by CLI arguments.",
     )
-    inputs: Dict[InputName, Input] = Field(
+    inputs: InputDict = Field(
         {},
         description="The TIMs input definitions used for receiving variables from the CLI",
     )

--- a/src/cr_kyoushi/generator/config.py
+++ b/src/cr_kyoushi/generator/config.py
@@ -5,6 +5,7 @@ This module contains the configuration model descriptions for the tool.
 import re
 
 from typing import (
+    Dict,
     List,
     Optional,
     Pattern,
@@ -13,6 +14,7 @@ from typing import (
 from pydantic import (
     BaseModel,
     Field,
+    StrictStr,
 )
 
 
@@ -54,6 +56,27 @@ class JinjaConfig(BaseModel):
     )
 
 
+class Input(BaseModel):
+    model: str = Field(
+        ..., description="The python type hint to use for loading this input"
+    )
+    required: bool = Field(False, description="If the input is required or not.")
+    prompt: Optional[str] = Field(
+        None,
+        description="The input prompt message to use when the required input is not passed via CLI.",
+    )
+    description: Optional[str] = Field(
+        None, description="A textual description of the input variable"
+    )
+    value: Optional[str] = Field(
+        None, description="The string encoded value assigned to the input"
+    )
+
+
+class InputName(StrictStr):
+    regex = re.compile(r"^[\w\d-]*$")
+
+
 class Config(BaseModel):
     """Kyoushi Generator tool configuration model
 
@@ -70,6 +93,12 @@ class Config(BaseModel):
                 block_end: '}'
                 variable_start: '\\var{'
                 variable_end: '}'
+            inputs:
+                employee_count:
+                    model: int
+                    required: true
+                    description: Number of employees that should be simulated in the testbed.
+                    prompt: Please enter the number of employees that should be created
         ```
     """
 
@@ -80,4 +109,8 @@ class Config(BaseModel):
     seed: Optional[int] = Field(
         None,
         description="A hard coded seed to use for instance creation with this model. Can be overwritten by CLI arguments.",
+    )
+    inputs: Dict[InputName, Input] = Field(
+        {},
+        description="The TIMs input definitions used for receiving variables from the CLI",
     )

--- a/src/cr_kyoushi/generator/template.py
+++ b/src/cr_kyoushi/generator/template.py
@@ -447,6 +447,7 @@ def render_tim(
     object_list: List[Union[File, Directory]],
     src_dir: Path,
     dest_dir: Path,
+    inputs: Dict[str, Any],
     global_context: Dict[str, Any],
     parent_context: Dict[str, Any] = {},
     delete_dirs: Optional[Deque[Path]] = None,
@@ -503,6 +504,7 @@ def render_tim(
                 obj.contents,
                 src,
                 dest,
+                inputs,
                 global_context,
                 new_parent_context,
                 delete_dirs,
@@ -511,6 +513,7 @@ def render_tim(
 
         elif isinstance(obj, File):
             context = {
+                "inputs": inputs,
                 "context": global_context,
                 "parent_context": parent_context,
                 "local_context": obj.extra,


### PR DESCRIPTION
This PR adds CLI input vars

Input vars can be specified via the command line option `--var` or through var files specified through `--var-file`.
Both command line options can be passed multiple times to specify multiple input vars or input var files. Input var values must be JSON encoded. The only exception to this are simple string values for convenience sake simple string do not have to be surrounded by double quotes (e.g., `--var foo=bar` will be accepted as the string `bar`).

Only input vars defined in the models CLI config (config.yml) will be loaded. The format for this configuration looks like this:

```yaml
inputs:
 some-var-name:
  model: List[str]  # required python type hint definition of the input variable
  required: false  # if the input var must be passed or is only optional (default false)
  default: '["foo", "bar"]' # JSON encoded default value for this input var. 
# value:  '["foo", "bar"]' # Alternatively the key `value` can be used instead of `default`.
  description: |
     Some long optional descriptive text explaining
     the purpose of this input var.
```

## Templating

Passed input vars are available in all 3 template environments (i.e., `context.yml.j2`, `templates.yml.j2`, and TIM templates).
They can be accessed via the `inputs` dictionary e.g., `{{ inputs.some-var-name }}`.

**!!! Note**
> With this PR the behavior of the `templates.yml.j2` changes. Previously the parsed context was made available at the top level of the templating environment i.e., a context var `company_name` could be accessed directly `{{ company_name }}`. With the addition of the `inputs` dictionary this behavior changes context vars in the `templates.yml.j2` templating environment must now be access through the `context` key i.e., -> `{{ context.company_name }}`.

## inspect command

The PR also adds a new command `inspect` making it possible to print nice overview of the available input vars for specified TIM.
```
$ cr-kyoushi-dataset inspect /some/tim
Input variables for /some/tim:
        asd (required) str:
          Well this is very cool and so.

        asd2 (optional) int:
          Well this is very cool and so.
          But this line is also cool.
          Yeah!!!!!

        asd3 (optional) List[Union[int, str]]:
          default: [1, 2, "3"]
          Well this is very cool and so.
          But this line is also cool.
          Yeah!!!!!
```