### PR TITLE
Move generators to `gen`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: Cyber Range Kyoushi Generator
-site_url: ""
+site_url: "https://ait-aecid.github.io/kyoushi-dataset"
 
 site_description: Cyber Range testbed generator for creating randomized instances of testbed models.
-strict: false
+strict: true
 
 theme:
   name: 'material'
@@ -20,10 +20,10 @@ extra_javascript:
   - js/jquery-3.5.1.min.js
   - js/jquery.fancybox.min.js
 
-repo_name: kyoushi/generator
-repo_url: https://git-service.ait.ac.at/sct-cyberrange/tools/kyoushi/generator
+repo_name: kyoushi-generator
+repo_url: https://github.com/ait-aecid/kyoushi-generator
 # need to set manually since we use a private gitlab instance
-edit_uri: edit/master/docs/
+edit_uri: edit/main/docs/
 
 nav:
 - Overview: index.md

--- a/src/cr_kyoushi/generator/cli.py
+++ b/src/cr_kyoushi/generator/cli.py
@@ -293,12 +293,12 @@ def setup_tsm(
     # remove template files
     while delete_files:
         f = dest.joinpath(delete_files.pop())
-        dest.joinpath(f).unlink()
+        f.unlink()
 
     # remove template directories
     while delete_dirs:
         d = dest.joinpath(delete_dirs.pop())
-        shutil.rmtree(dest.joinpath(d))
+        shutil.rmtree(d)
 
     return (context, object_config)
 

--- a/src/cr_kyoushi/generator/template.py
+++ b/src/cr_kyoushi/generator/template.py
@@ -261,9 +261,13 @@ def _env_add_generators(
         seed_store: The seed store to use for seed generation
         generators: The generators to add
     """
+    generator_dict = {}
+
     for gen in generators:
         gen_instance = gen.create(seed_store)
-        env.globals.update({gen.name: gen_instance})
+        generator_dict.update({gen.name: gen_instance})
+
+    env.globals["gen"] = generator_dict
 
 
 def create_context_environment(


### PR DESCRIPTION
This PR moves all generators from them top level Jinja2 context to the special key `gen` i.e.,

`{{ faker.name(...) }}` becomes `{{ gen.faker.name(...) }}`

We do this to make future generator name collisions with Jinja2 filters and globals less likely.

The PR also fixes a bug breaking the template object delete function. Due to a logic error the dest directory was pre-pended twice resulting in invalid paths.
Also the mkdocs config was set so that it actually reflects the github repositiory.
